### PR TITLE
Add endpoint_management attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ Apache-2.0 Licensed. See [LICENSE](https://github.com/aws-ia/terraform-aws-mwaa/
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.63.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.39.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.63.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.39.0 |
 
 ## Modules
 
@@ -136,6 +136,7 @@ No modules.
 | <a name="input_create_s3_bucket"></a> [create\_s3\_bucket](#input\_create\_s3\_bucket) | Create new S3 bucket for MWAA. | `string` | `true` | no |
 | <a name="input_create_security_group"></a> [create\_security\_group](#input\_create\_security\_group) | Create security group for MWAA | `bool` | `true` | no |
 | <a name="input_dag_s3_path"></a> [dag\_s3\_path](#input\_dag\_s3\_path) | (Required) The relative path to the DAG folder on your Amazon S3 storage bucket. For example, dags. | `string` | `"dags"` | no |
+| <a name="input_endpoint_management"></a> [endpoint\_management](#input\_endpoint\_management) | (Optional) Specifies who is responsible for creating the VPC endpoints for environment. CUSTOMER is useful when your VPC is owned by another account. Possible options: SERVICE (default) and CUSTOMER | `string` | `"SERVICE"` | no |
 | <a name="input_environment_class"></a> [environment\_class](#input\_environment\_class) | (Optional) Environment class for the cluster. Possible options are mw1.small, mw1.medium, mw1.large, mw1.xlarge, mw1.2xlarge.<br>Will be set by default to mw1.small. Please check the AWS Pricing for more information about the environment classes. | `string` | `"mw1.small"` | no |
 | <a name="input_execution_role_arn"></a> [execution\_role\_arn](#input\_execution\_role\_arn) | (Required) The Amazon Resource Name (ARN) of the task execution role that the Amazon MWAA and its environment can assume<br>Mandatory if `create_iam_role=false` | `string` | `null` | no |
 | <a name="input_force_detach_policies"></a> [force\_detach\_policies](#input\_force\_detach\_policies) | IAM role Force detach policies | `bool` | `false` | no |

--- a/main.tf
+++ b/main.tf
@@ -23,6 +23,7 @@ resource "aws_mwaa_environment" "mwaa" {
   source_bucket_arn               = local.source_bucket_arn
   webserver_access_mode           = var.webserver_access_mode
   weekly_maintenance_window_start = var.weekly_maintenance_window_start
+  endpoint_management             = var.endpoint_management
 
   tags = var.tags
 

--- a/variables.tf
+++ b/variables.tf
@@ -137,6 +137,17 @@ variable "weekly_maintenance_window_start" {
   default     = null
 }
 
+variable "endpoint_management" {
+  description = "(Optional) Specifies who is responsible for creating the VPC endpoints for environment. CUSTOMER is useful when your VPC is owned by another account. Possible options: SERVICE (default) and CUSTOMER"
+  type        = string
+  default     = "SERVICE"
+
+  validation {
+    condition     = contains(["SERVICE", "CUSTOMER"], var.endpoint_management)
+    error_message = "Invalid input, options: \"SERVICE\", \"CUSTOMER\"."
+  }
+}
+
 variable "tags" {
   description = "(Optional) A map of resource tags to associate with the resource"
   type        = map(string)

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.63.0"
+      version = ">= 5.39.0"
     }
   }
 }


### PR DESCRIPTION
### What does this PR do?

<!-- A brief description of the change being made with this pull request. -->
- Added support for the `endpoint_management` attribute on MWAA environments.
  - This allows you to create MWAA environments inside VPCs that are owned by other accounts, as long as you manually create the VPC endpoints required by Airflow.
- Bumped up the AWS provider requirements to the [earliest version that supports the new attribute](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.39.0)


### Motivation

We wanted to migrate our Airflow clusters, which were created with this module, to a shared VPC.

### More
- [X] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [X] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

- When deploying an environment with `endpoint_management="CUSTOMER"`, the cluster creation will hang until you've created the endpoint yourself. If it times out, you may need to `terraform untaint` the cluster after it's finished being created. This is a deficiency in the resource itself.
- Creating the endpoint via Terraform is not easy since the AWS provider does not have a `data` element for `aws_mwaa_environment`, and the attributes are not available via the resource until after it has been created.

#### Evidence of Deployment

Note that many values have been redacted for our own security:
```
> tf state show module.mwaa.aws_mwaa_environment.mwaa
# module.mwaa.aws_mwaa_environment.mwaa:
resource "aws_mwaa_environment" "mwaa" {
    airflow_configuration_options   = (sensitive value)
    airflow_version                 = "2.7.2"
    arn                             = "arn:aws:airflow:XXXXXX:XXXXXXXXXXXX:environment/XXXXXX"
    created_at                      = "2024-07-10 17:54:17 +0000 UTC"
    dag_s3_path                     = "dags/"
    endpoint_management             = "CUSTOMER" <------ This is the attribute I added
    environment_class               = "mw1.small"
    execution_role_arn              = "arn:aws:iam::XXXXXXXXXXXX:role/XXXXXX"
    id                              = "XXXXXX"
    last_updated                    = [
        {
            created_at = "2024-07-10 17:54:17 +0000 UTC"
            error      = []
            status     = "SUCCESS"
        },
    ]
    max_workers                     = 3
    min_workers                     = 3
    name                            = "XXXXXX"
    plugins_s3_object_version       = "XXXXXX"
    plugins_s3_path                 = "plugins/plugins.zip"
    requirements_s3_object_version  = "XXXXXX"
    requirements_s3_path            = "requirements/requirements.txt"
    schedulers                      = 2
    service_role_arn                = "arn:aws:iam::XXXXXXXXXXXX:role/aws-service-role/airflow.amazonaws.com/AWSServiceRoleForAmazonMWAA"
    source_bucket_arn               = "arn:aws:s3:::XXXXXX"
    status                          = "AVAILABLE"
    tags                            = {}
    tags_all                        = {
        ...
    }
    webserver_access_mode           = "PUBLIC_ONLY"
    webserver_url                   = "XXXXXX.XXXXXX.XXXXXX.airflow.amazonaws.com"
    weekly_maintenance_window_start = "MON:07:30"

    logging_configuration {
        ...
    }

    network_configuration {
        security_group_ids = [
            "sg-XXXXXX",
        ]
        subnet_ids         = [
            "subnet-XXXXXX", <------ These subnets do not belong to the account
            "subnet-XXXXXX",
        ]
    }
}
```


