### PR TITLE
Dops-support-worker-replacement-strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,13 +91,13 @@ Apache-2.0 Licensed. See [LICENSE](https://github.com/aws-ia/terraform-aws-mwaa/
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.39.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.11.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.39.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.11.0 |
 
 ## Modules
 
@@ -168,6 +168,7 @@ No modules.
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | (Required) VPC ID to deploy the MWAA Environment.<br/>Mandatory if `create_security_group=true` | `string` | `""` | no |
 | <a name="input_webserver_access_mode"></a> [webserver\_access\_mode](#input\_webserver\_access\_mode) | (Optional) Specifies whether the webserver should be accessible over the internet or via your specified VPC. Possible options: PRIVATE\_ONLY (default) and PUBLIC\_ONLY | `string` | `"PRIVATE_ONLY"` | no |
 | <a name="input_weekly_maintenance_window_start"></a> [weekly\_maintenance\_window\_start](#input\_weekly\_maintenance\_window\_start) | (Optional) Specifies the start date for the weekly maintenance window | `string` | `null` | no |
+| <a name="input_worker_replacement_strategy"></a> [worker\_replacement\_strategy](#input\_worker\_replacement\_strategy) | (Optional) The worker replacement strategy to use for your environment. Possible options: FORCED (default) and GRACEFUL | `string` | `"FORCED"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -19,6 +19,7 @@ resource "aws_mwaa_environment" "mwaa" {
   schedulers                       = var.schedulers
   execution_role_arn               = local.execution_role_arn
   airflow_configuration_options    = local.airflow_configuration_options
+  worker_replacement_strategy      = var.worker_replacement_strategy
 
   source_bucket_arn     = local.source_bucket_arn
   webserver_access_mode = var.webserver_access_mode

--- a/variables.tf
+++ b/variables.tf
@@ -78,6 +78,17 @@ variable "min_workers" {
   default     = 1
 }
 
+variable "worker_replacement_strategy" {
+  description = "(Optional) The worker replacement strategy to use for your environment. Possible options: FORCED (default) and GRACEFUL"
+  type        = string
+  default     = "FORCED"
+
+  validation {
+    condition     = contains(["FORCED", "GRACEFUL"], var.worker_replacement_strategy)
+    error_message = "Invalid input, options: \"FORCED\", \"GRACEFUL\"."
+  }
+}
+
 variable "plugins_s3_object_version" {
   description = "(Optional) The plugins.zip file version you want to use."
   type        = string

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.39.0"
+      version = ">= 6.11.0"
     }
   }
 }


### PR DESCRIPTION

### What does this PR do?

Adds the `worker_replacement_strategy` argument to the `aws_mwaa_environment` resource.


### Motivation

My team needed this additional arugment to have environment updates gracefully applied to the workers to avoid affecting currently running tasks.


### More
- [x] Yes, I have tested the PR using my local account setup  (Provide any test evidence report under Additional Notes)
- [x] Yes, I ran `pre-commit run -a` with this PR

### For Moderators
- [ ] E2E Test successfully complete before merge?

### Additional Notes

This forces a major version upgrade for the aws provider. I've done testing in my local environment and didn't encounter issues, but there may need to be additional E2E testing before merging.
